### PR TITLE
feat: created trainers_controller and trainers_routes, #6

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from database import engine
 from models.base import Base
 from routes.users_routes import router as users_router
+from routes.trainers_routes import router as trainers_router
 
 import models.user
 import models.trainer
@@ -14,6 +15,7 @@ app = FastAPI(
 )
 
 app.include_router(users_router)
+app.include_router(trainers_router)
 
 @app.on_event("startup")
 def startup():

--- a/controllers/trainers_controller.py
+++ b/controllers/trainers_controller.py
@@ -1,0 +1,75 @@
+from sqlalchemy.orm import Session
+from models.trainer import Trainer
+from schemas.trainer_schema import TrainerCreate, TrainerUpdate
+
+def create_trainer(db: Session, payload: TrainerCreate) -> Trainer:
+    trainer = Trainer(
+        user_id=payload.user_id,
+        specialty=payload.specialty,
+        is_active=True
+    )
+
+    db.add(trainer)
+    db.commit()
+    db.refresh(trainer)
+
+    return trainer
+
+def get_all_trainers(db: Session) -> list[Trainer]:
+    return db.query(Trainer).all()
+
+def get_trainer_by_id(db: Session, trainer_id: int) -> Trainer | None:
+    return db.query(Trainer).filter(Trainer.id == trainer_id).first()
+
+def update_trainer_specialty( db: Session, trainer_id: int, payload: TrainerUpdate) -> Trainer | None:
+    trainer = get_trainer_by_id(db, trainer_id)
+    if not trainer:
+        return None
+    if payload.specialty is not None:
+        trainer.specialty = payload.specialty
+
+    db.commit()
+    db.refresh(trainer)
+
+    return trainer
+
+def set_trainer_active_status( db: Session, trainer_id: int, is_active: bool) -> Trainer | None:
+    trainer = get_trainer_by_id(db, trainer_id)
+
+    if not trainer:
+        return None
+
+     # No se puede activar un trainer sin usuario
+    if is_active and not trainer.user_id:
+        raise ValueError("No es posible activar el entrenador si no tiene un usuario asociado")
+    
+    trainer.is_active = is_active
+
+    db.commit()
+    db.refresh(trainer)
+
+    return trainer
+
+def delete_trainer(db: Session, trainer_id: int) -> Trainer | None:
+    """
+    Soft delete: deactivate trainer
+    Rule: cannot delete trainer with active classes
+    """
+    trainer = get_trainer_by_id(db, trainer_id)
+
+    if not trainer:
+        return None
+
+    # No se puede eliminar si tiene al menos una clase activa
+    has_active_classes = any( user_class.is_active for user_class in trainer.classes)
+
+    if has_active_classes:
+        raise ValueError(
+            "No se puede eliminar el entrenador porque tiene clases activas")
+
+    trainer.is_active = False
+
+    db.commit()
+    db.refresh(trainer)
+
+    return trainer

--- a/models/trainer.py
+++ b/models/trainer.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey
 from sqlalchemy.orm import relationship
 
 from models.base import Base, TimestampMixin
@@ -9,6 +9,7 @@ class Trainer(Base, TimestampMixin):
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     specialty = Column(String(100), nullable=False)
+    is_active = Column(Boolean, default=True)
 
     user = relationship(
         "User",

--- a/routes/trainers_routes.py
+++ b/routes/trainers_routes.py
@@ -1,0 +1,82 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from database.database import get_db
+from schemas.trainer_schema import TrainerCreate, TrainerUpdate, TrainerResponse
+from controllers import trainers_controller
+
+router = APIRouter(
+    prefix="/trainers",
+    tags=["Trainers"]
+)
+
+@router.post( "/", response_model=TrainerResponse, status_code=status.HTTP_201_CREATED)
+def create_trainer(
+    payload: TrainerCreate,
+    db: Session = Depends(get_db)
+):
+    return trainers_controller.create_trainer(db, payload)
+
+@router.get( "/", response_model=list[TrainerResponse])
+def get_trainers(
+    db: Session = Depends(get_db)
+):
+    return trainers_controller.get_all_trainers(db)
+
+@router.get( "/{trainer_id}", response_model=TrainerResponse)
+def get_trainer(
+    trainer_id: int,
+    db: Session = Depends(get_db)
+):
+    trainer = trainers_controller.get_trainer_by_id(db, trainer_id)
+
+    if not trainer:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Entrenador no encontrado")
+    return trainer
+
+@router.put( "/{trainer_id}/specialty", response_model=TrainerResponse)
+def update_trainer_specialty(
+    trainer_id: int,
+    payload: TrainerUpdate,
+    db: Session = Depends(get_db)
+):
+    trainer = trainers_controller.update_trainer_specialty( db, trainer_id, payload)
+
+    if not trainer:
+        raise HTTPException( 
+            status_code=status.HTTP_404_NOT_FOUND, detail="Entrenador no encontrado")
+    return trainer
+
+@router.patch( "/{trainer_id}/active", response_model=TrainerResponse)
+def set_trainer_active_status(
+    trainer_id: int,
+    is_active: bool,
+    db: Session = Depends(get_db)
+):
+    try:
+        trainer = trainers_controller.set_trainer_active_status(db, trainer_id, is_active)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,detail=str(e))
+
+    if not trainer:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Entrenador no encontrado")
+    return trainer
+
+@router.delete( "/{trainer_id}", response_model=TrainerResponse)
+def delete_trainer(
+    trainer_id: int,
+    db: Session = Depends(get_db)
+):
+    try:
+        trainer = trainers_controller.delete_trainer(db, trainer_id)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    if not trainer:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Entrenador no encontrado")
+
+    return trainer
+


### PR DESCRIPTION
Creado el controlador en controllers/trainers_controller.py y el router en routes/trainers_routes.py

Implementado la lógica CRUD:

- Crear entrenador
- Obtener todos los entrenadores
- Obtener entrenador por ID
- Actualizar especialidad
- Activar / desactivar entrenador


Registrado el router en app.py

Validado la relación con la entidad User

Probado los endpoints con Postman:

POST /trainers
GET /trainers
GET /trainers/{id}
PUT /trainers/{id}
DELETE /trainers/{id}